### PR TITLE
chore: add description warning against spaces in agent name

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding-sre.yaml
+++ b/.github/ISSUE_TEMPLATE/onboarding-sre.yaml
@@ -32,6 +32,7 @@ body:
     id: agent-name
     attributes:
       label: Agent Name
+      description: Please avoid using spaces in the name.
       placeholder: my-itbench-agent
     validations:
       required: true


### PR DESCRIPTION
Signed-off-by: Takumi Yanagawa <yana@jp.ibm.com>