### PR TITLE
docs: fix spacing in applications readme

### DIFF
--- a/scenarios/sre/docs/applications.md
+++ b/scenarios/sre/docs/applications.md
@@ -15,6 +15,7 @@ ITBench uses various applications to offer a diverse set of environments for whi
 ### Book Info
 
 **Repository:** https://github.com/istio/istio
+
 **Description:** This microservice application is primarily used to showcase the capabitlities of Istio.
 
 **Resources:**
@@ -24,7 +25,9 @@ ITBench uses various applications to offer a diverse set of environments for whi
 ### OpenTelemetry Demo
 
 **Aliases:** Astronomy Shop
+
 **Repository:** https://github.com/open-telemetry/opentelemetry-demo
+
 **Description:** This microservice application is primarily used to showcase the capabitlities of OpenTelemetry.
 
 **Resources:**

--- a/scenarios/sre/roles/documentation/templates/readmes/applications.j2
+++ b/scenarios/sre/roles/documentation/templates/readmes/applications.j2
@@ -15,11 +15,13 @@ ITBench uses various applications to offer a diverse set of environments for whi
 
 {% for content in documentation_contents %}
 ### {{ content.name }}
-
 {% if content.aliases is defined %}
+
 **Aliases:** {{ content.aliases | join(", ") }}
 {% endif %}
+
 **Repository:** {{ content.repository }}
+
 **Description:** {{ content.description }}
 
 **Resources:**


### PR DESCRIPTION
This PR fixes the spacing in the `applications` README.