### PR TITLE
feat: add code change fault scenario

### DIFF
--- a/scenarios/sre/roles/scenarios/files/scenario_404/groundtruth.yaml
+++ b/scenarios/sre/roles/scenarios/files/scenario_404/groundtruth.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: itbench.io/v2
+kind: GroundTruth
+metadata:
+  name: scenario-404
+spec:
+  alerts:
+    - labels: {}
+      name: KubePodNotReady
+  entities:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: recommendation
+        namespace: otel-demo
+  solutions:
+    - - steps:
+          - command: kubectl -n otel-demo rollout undo deployment/recommendation
+            text: Revert the last change done to the manifest.
+      - steps:
+          - command: kubectl -n otel-demo edit deployment recommendation
+            text: Manually edit the manifest and replace the invalid image with the correct value.

--- a/scenarios/sre/roles/scenarios/files/scenario_404/groundtruth_v1.yaml
+++ b/scenarios/sre/roles/scenarios/files/scenario_404/groundtruth_v1.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: itbench.io/v1
+kind: GroundTruth
+metadata:
+  name: scenario-404
+spec:
+  alerts:
+    - group_id: recommendation-service-1
+      id: HighRequestErrorRate
+      metadata:
+        description: Recommendation service experiencing errors due to faulty container image
+    - group_id: frontend-service-1
+      id: HighRequestErrorRate
+      metadata:
+        description: Frontend experiencing errors when calling failed recommendation service
+    - group_id: frontend-proxy-service-1
+      id: HighRequestErrorRate
+      metadata:
+        description: Frontend-proxy experiencing cascading errors from frontend failures
+  aliases:
+    - - recommendation-deployment-1
+      - recommendation-service-1
+    - - frontend-service-1
+    - - frontend-proxy-service-1
+  fault:
+    - category: Change
+      condition: Deployment updated with image that causes request errors
+      entity:
+        group_id: recommendation-deployment-1
+        kind: Deployment
+        name: recommendation
+      fault_mechanism: modify-kubernetes-workload-container-image
+  groups:
+    - filter:
+        - recommendation-.*
+      id: recommendation-deployment-1
+      kind: Deployment
+      namespace: otel-demo
+      root_cause: true
+    - filter:
+        - recommendation\b
+      id: recommendation-service-1
+      kind: Service
+      namespace: otel-demo
+    - filter:
+        - frontend\b
+      id: frontend-service-1
+      kind: Service
+      namespace: otel-demo
+    - filter:
+        - frontend-proxy\b
+      id: frontend-proxy-service-1
+      kind: Service
+      namespace: otel-demo
+  propagations:
+    - condition: Recommendation deployment updated with faulty container image
+      effect: Recommendation service returns errors for all requests
+      source: recommendation-deployment-1
+      target: recommendation-service-1
+    - condition: Recommendation service returning errors
+      effect: Frontend experiences errors when fetching recommendations
+      source: recommendation-service-1
+      target: frontend-service-1
+    - condition: Frontend experiencing errors from recommendation failures
+      effect: Frontend-proxy experiences cascading errors
+      source: frontend-service-1
+      target: frontend-proxy-service-1
+  recommended_actions: []

--- a/scenarios/sre/roles/scenarios/files/scenario_404/scenario.yaml
+++ b/scenarios/sre/roles/scenarios/files/scenario_404/scenario.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: itbench.io/v2
+kind: Scenario
+metadata:
+  name: scenario-404
+spec:
+  applications:
+    opentelemetryDemo:
+      enabled: true
+  faults:
+    - injections:
+        - args:
+            container:
+              image: quay.io/shengkunrz/it-bench-dev:monzo-recommendation
+              name: recommendation
+            kubernetesObject:
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: recommendation
+                namespace: otel-demo
+          id: modify-kubernetes-workload-container-image
+  tools:
+    sre:
+      enabled: true


### PR DESCRIPTION
This PR adds code change fault scenario 404 from #344 . This PR needs some thought through as we don't want to make an open-ended fault like `otel-demo-flagd` and `chaos-mesh` since it can be hard to ascertain what the fault is doing and thus the alerts it triggers. Also, would these code changes mean we need to make and redeploy all of these botched images? 