### PR TITLE
chore: update non-DockerHub registries

### DIFF
--- a/scenarios/sre/project/roles/tools/defaults/main/managers.yaml
+++ b/scenarios/sre/project/roles/tools/defaults/main/managers.yaml
@@ -28,8 +28,8 @@ tools_managers:
   istio_base:
     helm:
       chart:
-        # renovate: datasource=docker depName=gcr.io/istio-release/charts/base
-        reference: oci://gcr.io/istio-release/charts/base
+        # renovate: datasource=docker depName=registry.istio.io/release/charts/base
+        reference: oci://registry.istio.io/release/charts/base
         version: 1.29.2
       release:
         name: istio-base
@@ -38,8 +38,8 @@ tools_managers:
   istio_cni:
     helm:
       chart:
-        # renovate: datasource=docker depName=gcr.io/istio-release/charts/cni
-        reference: oci://gcr.io/istio-release/charts/cni
+        # renovate: datasource=docker depName=registry.istio.io/release/charts/cni
+        reference: oci://registry.istio.io/release/charts/cni
         version: 1.29.2
       release:
         name: istio-cni
@@ -50,8 +50,8 @@ tools_managers:
   istio_istiod:
     helm:
       chart:
-        # renovate: datasource=docker depName=gcr.io/istio-release/charts/istiod
-        reference: oci://gcr.io/istio-release/charts/istiod
+        # renovate: datasource=docker depName=registry.istio.io/release/charts/istiod
+        reference: oci://registry.istio.io/release/charts/istiod
         version: 1.29.2
       release:
         name: istiod
@@ -60,8 +60,8 @@ tools_managers:
   istio_ztunnel:
     helm:
       chart:
-        # renovate: datasource=docker depName=gcr.io/istio-release/charts/ztunnel
-        reference: oci://gcr.io/istio-release/charts/ztunnel
+        # renovate: datasource=docker depName=registry.istio.io/release/charts/ztunnel
+        reference: oci://registry.istio.io/release/charts/ztunnel
         version: 1.29.2
       release:
         name: ztunnel

--- a/scenarios/sre/project/roles/tools/tasks/install_opentelemetry_collectors.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install_opentelemetry_collectors.yaml
@@ -89,7 +89,7 @@
                 - matchExpressions:
                     - key: node-role.itbench.io/sandbox
                       operator: DoesNotExist
-        image: docker.io/jaegertracing/jaeger:2.17.0
+        image: quay.io/jaegertracing/jaeger:2.17.0
         mode: deployment
         observability:
           metrics:

--- a/scenarios/sre/project/roles/tools/tasks/install_opentelemetry_collectors.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install_opentelemetry_collectors.yaml
@@ -89,7 +89,7 @@
                 - matchExpressions:
                     - key: node-role.itbench.io/sandbox
                       operator: DoesNotExist
-        image: docker.io/jaegertracing/jaeger:2.18.0
+        image: quay.io/jaegertracing/jaeger:2.18.0
         mode: deployment
         observability:
           metrics:


### PR DESCRIPTION
This PR updates some of the container registries to use non DockerHub official sources to avoid hitting the rate limit error.