### PR TITLE
feat: add v2 cluster tasks

### DIFF
--- a/scenarios/sre/playbooks/clear_kubernetes_events.yaml
+++ b/scenarios/sre/playbooks/clear_kubernetes_events.yaml
@@ -20,8 +20,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: "{{ system_oc_exists }}"
   tasks:
     - name: Retrieve all events
       kubernetes.core.k8s_info:

--- a/scenarios/sre/playbooks/generate_agent_bundle.yaml
+++ b/scenarios/sre/playbooks/generate_agent_bundle.yaml
@@ -20,8 +20,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: "{{ system_oc_exists }}"
 
     - name: Validate that storage is configured
       ansible.builtin.assert:

--- a/scenarios/sre/playbooks/manage_applications.yaml
+++ b/scenarios/sre/playbooks/manage_applications.yaml
@@ -20,8 +20,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: "{{ system_oc_exists }}"
   tasks:
     - name: Import role variables from scenario
       tags:

--- a/scenarios/sre/playbooks/manage_awx.yaml
+++ b/scenarios/sre/playbooks/manage_awx.yaml
@@ -20,8 +20,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ stack.awx.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: "{{ system_oc_exists }}"
   tasks:
     - name: Import role variables
       tags:

--- a/scenarios/sre/playbooks/manage_recorders.yaml
+++ b/scenarios/sre/playbooks/manage_recorders.yaml
@@ -20,8 +20,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: "{{ system_oc_exists }}"
   tasks:
     - name: Import role variables from scenario
       tags:

--- a/scenarios/sre/playbooks/manage_tools.yaml
+++ b/scenarios/sre/playbooks/manage_tools.yaml
@@ -20,8 +20,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: "{{ system_oc_exists }}"
   tasks:
     - name: Import role variables from scenario
       tags:

--- a/scenarios/sre/roles/cluster/meta/argument_specs.yaml
+++ b/scenarios/sre/roles/cluster/meta/argument_specs.yaml
@@ -11,10 +11,3 @@ argument_specs:
           kubeconfig:
             required: true
             type: str
-      cluster_tools_enabled:
-        required: true
-        type: dict
-        options:
-          oc:
-            required: true
-            type: bool

--- a/scenarios/sre/roles/cluster/tasks/approve_certificate_requests.yaml
+++ b/scenarios/sre/roles/cluster/tasks/approve_certificate_requests.yaml
@@ -7,7 +7,7 @@
     field_selectors:
       - spec.signerName=kubernetes.io/kubelet-serving
     wait: true
-  register: cluster_csr_info
+  register: cluster_certificate_requests
 
 - name: Approve pending certificates
   ansible.builtin.command:
@@ -15,28 +15,30 @@
       - kubectl
       - certificate
       - approve
-      - "{{ item.metadata.name }}"
+      - "{{ request.metadata.name }}"
       - "--kubeconfig={{ cluster_files.kubeconfig | ansible.builtin.expanduser }}"
   register: cluster_certs_approve_output
   changed_when: cluster_certs_approve_output.rc == 0
-  loop: "{{ cluster_csr_info.resources }}"
+  loop: "{{ cluster_certificate_requests.resources }}"
   loop_control:
-    label: "csr/{{ item.metadata.name }}"
+    label: "certificatesigningrequest/{{ request.metadata.name }}"
+    loop_var: request
   when:
-    - item.status.conditions is not defined
+    - request.status.conditions is not defined
 
 - name: Wait for approvals to clear
   kubernetes.core.k8s_info:
     api_version: certificates.k8s.io/v1
     kind: CertificateSigningRequest
     kubeconfig: "{{ cluster_files.kubeconfig }}"
-    name: "{{ item.metadata.name }}"
+    name: "{{ request.metadata.name }}"
     wait: true
     wait_condition:
       type: Approved
       status: "True"
-  loop: "{{ cluster_csr_info.resources }}"
+  loop: "{{ cluster_certificate_requests.resources }}"
   loop_control:
-    label: "csr/{{ item.metadata.name }}"
+    label: "certificatesigningrequest/{{ request.metadata.name }}"
+    loop_var: request
   when:
-    - item.status.conditions is not defined
+    - request.status.conditions is not defined

--- a/scenarios/sre/roles/cluster/tasks/set_cluster_platform.yaml
+++ b/scenarios/sre/roles/cluster/tasks/set_cluster_platform.yaml
@@ -1,39 +1,28 @@
 ---
-- name: Display message
-  ansible.builtin.debug:
-    msg:
-      - Unable to find the OpenShift CLI (oc). Assuming it is not installed.
-      - The cluster provider variable will be set to 'kubernetes' because the OpenShift version cannot be determined.
-  when:
-    - not (cluster_tools_enabled.oc | bool)
+- name: Retrieve cluster information
+  kubernetes.core.k8s_cluster_info:
+    kubeconfig: "{{ cluster_files.kubeconfig }}"
+  register: cluster_information
 
-- name: Set cluster platform variable
+- name: Determine if OpenShift or Kubernetes based on presence of OpenShift APIs
   ansible.builtin.set_fact:
-    cluster_platform: kubernetes
-  when:
-    - not (cluster_tools_enabled.oc | bool)
-
-- name: Retrieve cluster version information using OpenShift CLI
-  ansible.builtin.command:
-    argv:
-      - oc
-      - version
-      - -o
-      - json
-      - --kubeconfig={{ cluster_files.kubeconfig | ansible.builtin.expanduser }}
-  register: cluster_raw_oc_version
-  changed_when: false
-  when:
-    - cluster_tools_enabled.oc | bool
-
-- name: Convert version output into JSON object
-  ansible.builtin.set_fact:
-    cluster_oc_version: "{{ cluster_raw_oc_version.stdout | from_json }}"
-  when:
-    - cluster_tools_enabled.oc | bool
-
-- name: Set cluster platform variable based on version output
-  ansible.builtin.set_fact:
-    cluster_platform: "{{ 'openshift' if cluster_oc_version.openshiftVersion is defined else 'kubernetes' }}"
-  when:
-    - cluster_tools_enabled.oc | bool
+    cluster_platform: |-
+      {{
+        (
+          (
+            cluster_information.apis.keys() |
+            ansible.builtin.intersect(openshift_apis) |
+            ansible.builtin.length
+          ) ==
+          (
+            openshift_apis |
+            ansible.builtin.length
+          )
+        ) |
+        ansible.builtin.ternary("openshift", "kubernetes")
+      }}
+  vars:
+    openshift_apis:
+      - route.openshift.io/v1
+      - project.openshift.io/v1
+      - config.openshift.io/v1

--- a/scenarios/sre/roles/cluster/tasks/set_cluster_provider.yaml
+++ b/scenarios/sre/roles/cluster/tasks/set_cluster_provider.yaml
@@ -6,8 +6,17 @@
     kubeconfig: "{{ cluster_files.kubeconfig }}"
     label_selectors:
       - node-role.kubernetes.io/control-plane =
-  register: cluster_control_nodes_info
+  register: cluster_control_nodes
 
-- name: Set cluster provider variable as control node(s) provider id information
+- name: Extract provider information from control nodes
   ansible.builtin.set_fact:
-    cluster_provider: "{{ cluster_control_nodes_info.resources[0].spec.providerID | split(':') | first }}"
+    cluster_provider: |-
+      {{
+        cluster_control_nodes.resources |
+        ansible.builtin.selectattr("spec.providerID", "defined") |
+        map(attribute="spec.providerID") |
+        map("ansible.builtin.split", ":") |
+        map("ansible.builtin.first") |
+        ansible.builtin.unique |
+        ansible.builtin.first
+      }}

--- a/scenarios/sre/roles/cluster/tasks/set_cluster_provider.yaml
+++ b/scenarios/sre/roles/cluster/tasks/set_cluster_provider.yaml
@@ -1,18 +1,16 @@
 ---
-- name: Retrieve all control nodes
+- name: Retrieve all nodes
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Node
     kubeconfig: "{{ cluster_files.kubeconfig }}"
-    label_selectors:
-      - node-role.kubernetes.io/control-plane =
-  register: cluster_control_nodes
+  register: cluster_nodes
 
-- name: Extract provider information from control nodes
+- name: Extract provider information
   ansible.builtin.set_fact:
     cluster_provider: |-
       {{
-        cluster_control_nodes.resources |
+        cluster_nodes.resources |
         ansible.builtin.selectattr("spec.providerID", "defined") |
         map(attribute="spec.providerID") |
         map("ansible.builtin.split", ":") |

--- a/scenarios/sre/roles/recorders/molecule/install_recorders/cleanup.yml
+++ b/scenarios/sre/roles/recorders/molecule/install_recorders/cleanup.yml
@@ -9,8 +9,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import recorders role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/recorders/molecule/install_recorders/converge.yml
+++ b/scenarios/sre/roles/recorders/molecule/install_recorders/converge.yml
@@ -9,8 +9,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import recorders role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/recorders/molecule/install_recorders/create.yml
+++ b/scenarios/sre/roles/recorders/molecule/install_recorders/create.yml
@@ -17,8 +17,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import tools role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/recorders/molecule/install_recorders/destroy.yml
+++ b/scenarios/sre/roles/recorders/molecule/install_recorders/destroy.yml
@@ -11,8 +11,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import tools role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/tools/molecule/install_finops/cleanup.yml
+++ b/scenarios/sre/roles/tools/molecule/install_finops/cleanup.yml
@@ -9,8 +9,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import tools role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/tools/molecule/install_finops/converge.yml
+++ b/scenarios/sre/roles/tools/molecule/install_finops/converge.yml
@@ -9,8 +9,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import tools role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/tools/molecule/install_sre/cleanup.yml
+++ b/scenarios/sre/roles/tools/molecule/install_sre/cleanup.yml
@@ -9,8 +9,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import tools role
       ansible.builtin.import_role:

--- a/scenarios/sre/roles/tools/molecule/install_sre/converge.yml
+++ b/scenarios/sre/roles/tools/molecule/install_sre/converge.yml
@@ -9,8 +9,6 @@
       vars:
         cluster_files:
           kubeconfig: "{{ cluster.kubeconfig }}"
-        cluster_tools_enabled:
-          oc: false
 
     - name: Import tools role
       ansible.builtin.import_role:


### PR DESCRIPTION
This PR brings the cluster role to v2 standard, including not using `oc` to determine if a Kubernetes cluster over and OpenShift one.