### PR TITLE
fix: correct benchmark registration scheduling variable value

### DIFF
--- a/.github/workflows/benchmark_registration.yaml
+++ b/.github/workflows/benchmark_registration.yaml
@@ -128,7 +128,7 @@ jobs:
 
           response_json='${{steps.parse.outputs.payload}}'
 
-          benchmark_body=$(echo $response_json | jq  '{ "name" : ."Benchmark Name", "immediate" : ."Schedule Now"}' | jq --arg AGENT_ID ${{steps.get-agent-config.outputs.agent_id}} '. += {"agent_id": $AGENT_ID}')
+          benchmark_body=$(echo $response_json | jq  '{ "name" : ."Benchmark Name", "immediate" : (."Schedule Now" == "true")}' | jq --arg AGENT_ID ${{steps.get-agent-config.outputs.agent_id}} '. += {"agent_id": $AGENT_ID}')
 
           echo $benchmark_body | jq
 


### PR DESCRIPTION
Closes #541

## Before

When a user submitted a benchmark registration issue with `Schedule Now: true`, the workflow in `.github/workflows/benchmark_registration.yaml` passed the raw string `"true"` as the value of the `immediate` field in the JSON body sent to the benchmark API:

```json
{ "name": "my-ciso-agent-benchmark", "immediate": "true", "agent_id": "..." }
```

A string `"true"` is not the same as a boolean `true`. Depending on the API's type strictness, this would either fail validation or silently mis-schedule the benchmark (treating it as a non-immediate run or erroring on type mismatch).

## After

The `immediate` field is now correctly coerced to a JSON boolean using a jq comparison expression `(."Schedule Now" == "true")`:

```json
{ "name": "my-ciso-agent-benchmark", "immediate": true, "agent_id": "..." }
```

## Changes

- **`.github/workflows/benchmark_registration.yaml`, line 131**: In the `benchmark_body` construction step, replaced `. "Schedule Now"` with `(."Schedule Now" == "true")` in the first `jq` filter. The comparison evaluates the string field from the issue payload and produces a proper JSON boolean, which is then merged with the agent ID before being sent to the API.

## Testing

Manually verify by triggering the registration workflow with `Schedule Now: true` and inspecting the echoed `benchmark_body` (the `echo $benchmark_body | jq` line immediately after):

```json
{
  "name": "my-ciso-agent-benchmark",
  "immediate": true,
  "agent_id": "<agent-id>"
}
```

Confirm `immediate` is unquoted (boolean), not `"true"` (string). Also verify with `Schedule Now: false` to confirm the expression produces `false` rather than the string `"false"`.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*