### PR TITLE
chore: update otel demo helm values

### DIFF
--- a/scenarios/sre/project/roles/agent/molecule/grant_access/create.yml
+++ b/scenarios/sre/project/roles/agent/molecule/grant_access/create.yml
@@ -38,11 +38,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-app
+                "app.kubernetes.io/name": test-app
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-app
+                  "app.kubernetes.io/name": test-app
               spec:
                 containers:
                   - name: server
@@ -68,11 +68,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-tool
+                "app.kubernetes.io/name": test-tool
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-tool
+                  "app.kubernetes.io/name": test-tool
               spec:
                 containers:
                   - name: observer

--- a/scenarios/sre/project/roles/agent/molecule/revoke_access/create.yml
+++ b/scenarios/sre/project/roles/agent/molecule/revoke_access/create.yml
@@ -38,11 +38,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-app
+                "app.kubernetes.io/name": test-app
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-app
+                  "app.kubernetes.io/name": test-app
               spec:
                 containers:
                   - name: server
@@ -68,11 +68,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-tool
+                "app.kubernetes.io/name": test-tool
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-tool
+                  "app.kubernetes.io/name": test-tool
               spec:
                 containers:
                   - name: observer

--- a/scenarios/sre/project/roles/agent/tasks/grant.yaml
+++ b/scenarios/sre/project/roles/agent/tasks/grant.yaml
@@ -45,8 +45,8 @@
       kind: Role
       metadata:
         labels:
-          app.kubernetes.io/component: agent-access-provider
-          app.kubernetes.io/managed-by: ITBench
+          "app.kubernetes.io/component": agent-access-provider
+          "app.kubernetes.io/managed-by": ITBench
         name: agent-read-write-access
         namespace: "{{ ns }}"
       rules:
@@ -126,8 +126,8 @@
       kind: RoleBinding
       metadata:
         labels:
-          app.kubernetes.io/component: agent-access-provider
-          app.kubernetes.io/managed-by: ITBench
+          "app.kubernetes.io/component": agent-access-provider
+          "app.kubernetes.io/managed-by": ITBench
         name: agent-read-write-access
         namespace: "{{ ns }}"
       subjects:

--- a/scenarios/sre/project/roles/applications/tasks/install_book_info.yaml
+++ b/scenarios/sre/project/roles/applications/tasks/install_book_info.yaml
@@ -20,7 +20,7 @@
       kind: Namespace
       metadata:
         labels:
-          prometheus.itbench.io/monitor: "true"
+          "prometheus.itbench.io/monitor": "true"
         name: "{{ applications_managers.book_info.kubernetes.namespace }}"
     state: present
 
@@ -206,24 +206,24 @@
       kind: Deployment
       metadata:
         labels:
-          app.kubernetes.io/component: load-generator
-          app.kubernetes.io/managed-by: ITBench
-          app.kubernetes.io/part-of: bookinfo
+          "app.kubernetes.io/component": load-generator
+          "app.kubernetes.io/managed-by": ITBench
+          "app.kubernetes.io/part-of": bookinfo
         name: load-generator-product-page
         namespace: "{{ applications_managers.book_info.kubernetes.namespace }}"
       spec:
         replicas: 3
         selector:
           matchLabels:
-            app.kubernetes.io/component: load-generator
-            app.kubernetes.io/managed-by: ITBench
-            app.kubernetes.io/part-of: bookinfo
+            "app.kubernetes.io/component": load-generator
+            "app.kubernetes.io/managed-by": ITBench
+            "app.kubernetes.io/part-of": bookinfo
         template:
           metadata:
             labels:
-              app.kubernetes.io/component: load-generator
-              app.kubernetes.io/managed-by: ITBench
-              app.kubernetes.io/part-of: bookinfo
+              "app.kubernetes.io/component": load-generator
+              "app.kubernetes.io/managed-by": ITBench
+              "app.kubernetes.io/part-of": bookinfo
           spec:
             containers:
               - name: generator

--- a/scenarios/sre/project/roles/applications/tasks/install_opentelemetry_demo.yaml
+++ b/scenarios/sre/project/roles/applications/tasks/install_opentelemetry_demo.yaml
@@ -1,14 +1,9 @@
 ---
 # Note: The Prometheus offered by OpenShift is v2, while the one installed
 #       in the chart is v3. While otel-demo supports the `otlphttp` exporter,
-#       this is not easily exposed in OpenShift. So, IT-Bench uses the `prometheus`
+#       this is not easily exposed in OpenShift. So, ITBench uses the `prometheus`
 #       exporter instead to support both platforms until the functionality of
 #       Prometheus is the same on both platforms.
-
-# Note: Due to a Helm bug, the value of the `otlphttp` and `opensearch` exports cannot
-#       be set to null in order to remove the chart's values. So, the configuration of
-#       the exporters is still correctly set, but not used for forwarding the data.
-#       Requires backport: https://github.com/helm/helm/issues/30587
 
 - name: Create Namespace
   kubernetes.core.k8s:
@@ -38,6 +33,40 @@
     tools_cluster:
       kubeconfig: "{{ applications_cluster.kubeconfig }}"
       platform: "{{ applications_cluster.platform }}"
+
+- name: Create Service Account with `anyuid` access
+  when:
+    - applications_cluster.platform == "openshift"
+  block:
+    - name: Create ServiceAccount for OpenTelemetry Demo
+      kubernetes.core.k8s:
+        kubeconfig: "{{ applications_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: "{{ applications_managers.opentelemetry_demo.helm.release.name }}"
+            namespace: "{{ applications_managers.opentelemetry_demo.kubernetes.namespace }}"
+        state: present
+
+    - name: Create RoleBinding for access to anyuid SecurityContextConstraint
+      kubernetes.core.k8s:
+        kubeconfig: "{{ applications_cluster.kubeconfig }}"
+        resource_definition:
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          metadata:
+            name: "{{ applications_managers.opentelemetry_demo.helm.release.name }}"
+            namespace: "{{ applications_managers.opentelemetry_demo.kubernetes.namespace }}"
+          subjects:
+            - kind: ServiceAccount
+              name: "{{ applications_managers.opentelemetry_demo.helm.release.name }}"
+              namespace: "{{ applications_managers.opentelemetry_demo.kubernetes.namespace }}"
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: system:openshift:scc:anyuid
+        state: present
 
 - name: Install OpenTelemetry Demo (Astronomy Shop)
   kubernetes.core.helm:

--- a/scenarios/sre/project/roles/applications/templates/helm/otel_demo/values.j2
+++ b/scenarios/sre/project/roles/applications/templates/helm/otel_demo/values.j2
@@ -180,10 +180,8 @@ opentelemetry-collector:
         endpoint: {{ tools_clickhouse_endpoint.http }}
         logs_table_name: otel_demo_logs
         traces_table_name: otel_demo_traces
-      opensearch:
-        http:
-          endpoint: http://opensearch-master.opensearch.svc.cluster.local:9200
-      otlp:
+      opensearch: null
+      otlp/jaeger:
         endpoint: {{ tools_jaeger_endpoint.collector.grpc }}
       otlphttp/prometheus:
         endpoint: {{ tools_prometheus_endpoint.http }}
@@ -203,7 +201,7 @@ opentelemetry-collector:
           exporters:
             - clickhouse
             - debug
-            - otlp
+            - otlp/jaeger
             - spanmetrics
       telemetry:
         metrics:

--- a/scenarios/sre/project/roles/applications/templates/helm/otel_demo/values.j2
+++ b/scenarios/sre/project/roles/applications/templates/helm/otel_demo/values.j2
@@ -180,11 +180,10 @@ opentelemetry-collector:
         endpoint: {{ tools_clickhouse_endpoint.http }}
         logs_table_name: otel_demo_logs
         traces_table_name: otel_demo_traces
-      opensearch: null
+      opensearch: ~
       otlp/jaeger:
         endpoint: {{ tools_jaeger_endpoint.collector.grpc }}
-      otlphttp/prometheus:
-        endpoint: {{ tools_prometheus_endpoint.http }}
+      otlphttp/prometheus: ~
       prometheus:
         endpoint: 0.0.0.0:8888
     service:

--- a/scenarios/sre/project/roles/applications/templates/helm/otel_demo/values.j2
+++ b/scenarios/sre/project/roles/applications/templates/helm/otel_demo/values.j2
@@ -1,10 +1,11 @@
 ---
+{% if applications_cluster.platform == "openshift" %}
+serviceAccount:
+  create: false
+  name: {{ applications_managers.opentelemetry_demo.helm.release.name }}
+{% endif %}
 components:
   accounting:
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 1654
@@ -16,10 +17,6 @@ components:
         cpu: 250m
         memory: 256Mi
   ad:
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     resources:
       limits:
         cpu: 150m
@@ -27,64 +24,17 @@ components:
       requests:
         cpu: 50m
         memory: 256Mi
-{% if applications_cluster.platform == "openshift" %}
-  cart:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  checkout:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  currency:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  email:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  flagd:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
   fraud-detection:
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     resources:
       limits:
         memory: 512Mi
       requests:
         memory: 256Mi
-{% if applications_cluster.platform == "openshift" %}
-  frontend:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  frontend-proxy:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
   image-provider:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     podSecurityContext:
       runAsNonRoot: true
       runAsUser: 101
   kafka:
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     resources:
       limits:
         memory: 1024Mi
@@ -113,38 +63,11 @@ components:
             ansible.builtin.default(50) |
             ansible.builtin.string
           }}
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  payment:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
-  postgresql:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
   product-catalog:
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     resources:
       limits:
         memory: 160Mi
-{% if applications_cluster.platform == "openshift" %}
-  quote:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
   recommendation:
-{% if applications_cluster.platform == "openshift" %}
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     resources:
       limits:
         cpu: 200m
@@ -152,16 +75,7 @@ components:
       requests:
         cpu: 50m
         memory: 128Mi
-{% if applications_cluster.platform == "openshift" %}
-  shipping:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
-{% if applications_cluster.platform == "openshift" %}
   valkey-cart:
-    podAnnotations:
-      openshift.io/required-scc: restricted-v2
-{% endif %}
     podSecurityContext:
       runAsGroup: 1000
       runAsNonRoot: true
@@ -180,10 +94,8 @@ opentelemetry-collector:
         endpoint: {{ tools_clickhouse_endpoint.http }}
         logs_table_name: otel_demo_logs
         traces_table_name: otel_demo_traces
-      opensearch: ~
       otlp/jaeger:
         endpoint: {{ tools_jaeger_endpoint.collector.grpc }}
-      otlphttp/prometheus: ~
       prometheus:
         endpoint: 0.0.0.0:8888
     service:
@@ -224,10 +136,6 @@ opentelemetry-collector:
     metricsEndpoints:
       - port: metrics
       - port: telemetry
-{% if applications_cluster.platform == "openshift" %}
-  podAnnotations:
-    openshift.io/required-scc: restricted-v2
-{% endif %}
   ports:
     jaeger-compact:
       enabled: false

--- a/scenarios/sre/project/roles/faults/molecule/inject_cordoned_kubernetes_worker_node/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_cordoned_kubernetes_worker_node/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_crashing_kubernetes_workload_init_container/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_crashing_kubernetes_workload_init_container/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_failing_name_resolution_kubernetes_workload_dns_policy/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_failing_name_resolution_kubernetes_workload_dns_policy/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_hanging_kubernetes_workload_init_container/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_hanging_kubernetes_workload_init_container/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_ingress_port_blocking_network_policy/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_ingress_port_blocking_network_policy/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server
@@ -57,7 +57,7 @@
             namespace: ingress-port-blocking-network-policy-test
           spec:
             selector:
-              app.kubernetes.io/name: compromised-workload
+              "app.kubernetes.io/name": compromised-workload
             ports:
               - protocol: TCP
                 port: 8080

--- a/scenarios/sre/project/roles/faults/molecule/inject_insufficient_kubernetes_resource_quota/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_insufficient_kubernetes_resource_quota/create.yml
@@ -26,11 +26,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_insufficient_kubernetes_workload_container_resources/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_insufficient_kubernetes_workload_container_resources/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_invalid_kubernetes_workload_container_command/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_invalid_kubernetes_workload_container_command/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_misconfigured_kubernetes_horizontal_pod_autoscaler/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_misconfigured_kubernetes_horizontal_pod_autoscaler/create.yml
@@ -59,11 +59,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-workload
+                "app.kubernetes.io/name": test-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-workload
+                  "app.kubernetes.io/name": test-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_misconfigured_kubernetes_workload_container_readiness_probe/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_misconfigured_kubernetes_workload_container_readiness_probe/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_modified_kubernetes_workload_container_environment_variable/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_modified_kubernetes_workload_container_environment_variable/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_modified_target_port_kubernetes_service/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_modified_target_port_kubernetes_service/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server
@@ -57,7 +57,7 @@
             namespace: modified-target-port-kubernetes-service-test
           spec:
             selector:
-              app.kubernetes.io/name: compromised-workload
+              "app.kubernetes.io/name": compromised-workload
             ports:
               - protocol: TCP
                 port: 80

--- a/scenarios/sre/project/roles/faults/molecule/inject_nonexistent_kubernetes_workload_container_image/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_nonexistent_kubernetes_workload_container_image/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_nonexistent_kubernetes_workload_node/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_nonexistent_kubernetes_workload_node/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_nonexistent_kubernetes_workload_persistent_volume_claim/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_nonexistent_kubernetes_workload_persistent_volume_claim/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_priority_kubernetes_workload_priority_preemption/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_priority_kubernetes_workload_priority_preemption/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_scaled_to_zero_kubernetes_workload/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_scaled_to_zero_kubernetes_workload/create.yml
@@ -26,11 +26,11 @@
             replicas: 3
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_scheduled_chaos_mesh_experiment/converge.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_scheduled_chaos_mesh_experiment/converge.yml
@@ -44,4 +44,4 @@
                     namespaces:
                       - scheduled-chaos-test
                     labelSelectors:
-                      app.kubernetes.io/name: test-workload
+                      "app.kubernetes.io/name": test-workload

--- a/scenarios/sre/project/roles/faults/molecule/inject_scheduled_chaos_mesh_experiment/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_scheduled_chaos_mesh_experiment/create.yml
@@ -55,11 +55,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-workload
+                "app.kubernetes.io/name": test-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-workload
+                  "app.kubernetes.io/name": test-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_strict_mutual_tls_istio_service_mesh_enforcement/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_strict_mutual_tls_istio_service_mesh_enforcement/create.yml
@@ -54,11 +54,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-workload
+                "app.kubernetes.io/name": test-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-workload
+                  "app.kubernetes.io/name": test-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_unassigned_kubernetes_workload_container_resource_limits/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_unassigned_kubernetes_workload_container_resource_limits/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_unschedulable_kubernetes_workload_pod_anti_affinity_rule/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_unschedulable_kubernetes_workload_pod_anti_affinity_rule/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_unsupported_architecture_kubernetes_workload_container_image/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_unsupported_architecture_kubernetes_workload_container_image/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/faults/molecule/inject_valkey_workload_changed_password/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_valkey_workload_changed_password/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: valkey

--- a/scenarios/sre/project/roles/faults/molecule/inject_valkey_workload_out_of_memory/create.yml
+++ b/scenarios/sre/project/roles/faults/molecule/inject_valkey_workload_out_of_memory/create.yml
@@ -26,11 +26,11 @@
             replicas: 1
             selector:
               matchLabels:
-                app.kubernetes.io/name: compromised-workload
+                "app.kubernetes.io/name": compromised-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: compromised-workload
+                  "app.kubernetes.io/name": compromised-workload
               spec:
                 containers:
                   - name: valkey

--- a/scenarios/sre/project/roles/faults/tasks/inject_priority_kubernetes_workload_priority_preemption.yaml
+++ b/scenarios/sre/project/roles/faults/tasks/inject_priority_kubernetes_workload_priority_preemption.yaml
@@ -110,18 +110,18 @@
       kind: Deployment
       metadata:
         labels:
-          app.kubernetes.io/name: critical-data-collector
+          "app.kubernetes.io/name": critical-data-collector
         name: critical-data-collector
         namespace: "{{ faults_workload.resources[0].metadata.namespace }}"
       spec:
         replicas: "{{ replicas + 1 }}"
         selector:
           matchLabels:
-            app.kubernetes.io/name: critical-data-collector
+            "app.kubernetes.io/name": critical-data-collector
         template:
           metadata:
             labels:
-              app.kubernetes.io/name: critical-data-collector
+              "app.kubernetes.io/name": critical-data-collector
           spec:
             containers:
               - name: worker

--- a/scenarios/sre/project/roles/faults/tasks/inject_unschedulable_kubernetes_workload_pod_anti_affinity_rule.yaml
+++ b/scenarios/sre/project/roles/faults/tasks/inject_unschedulable_kubernetes_workload_pod_anti_affinity_rule.yaml
@@ -24,17 +24,17 @@
       kind: DaemonSet
       metadata:
         labels:
-          app.kubernetes.io/name: application-operator
+          "app.kubernetes.io/name": application-operator
         name: application-operator
         namespace: "{{ faults_workload.resources[0].metadata.namespace }}"
       spec:
         selector:
           matchLabels:
-            app.kubernetes.io/name: application-operator
+            "app.kubernetes.io/name": application-operator
         template:
           metadata:
             labels:
-              app.kubernetes.io/name: application-operator
+              "app.kubernetes.io/name": application-operator
           spec:
             containers:
               - name: worker

--- a/scenarios/sre/project/roles/tools/tasks/install_clickhouse_instances.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install_clickhouse_instances.yaml
@@ -67,7 +67,7 @@
       kind: ClickHouseInstallation
       metadata:
         labels:
-          app.kubernetes.io/name: clickhouse
+          "app.kubernetes.io/name": clickhouse
           app.kubernetes.io/version: 25.3.8.10041
         name: "{{ tools_managers.clickhouse_operator.instances.names.main }}"
         namespace: "{{ tools_managers.clickhouse_operator.instances.kubernetes.namespace }}"
@@ -115,7 +115,7 @@
             - name: pod-template
               metadata:
                 labels:
-                  app.kubernetes.io/name: clickhouse
+                  "app.kubernetes.io/name": clickhouse
                   app.kubernetes.io/version: 25.3.8.10041
               spec:
                 affinity:
@@ -167,7 +167,7 @@
             - name: service-template
               metadata:
                 labels:
-                  app.kubernetes.io/name: clickhouse
+                  "app.kubernetes.io/name": clickhouse
                   app.kubernetes.io/version: 25.3.8.10041
               spec:
                 type: ClusterIP
@@ -182,7 +182,7 @@
                     port: 9363
                     targetPort: 9363
                 selector:
-                  app.kubernetes.io/name: clickhouse
+                  "app.kubernetes.io/name": clickhouse
           volumeClaimTemplates:
             - name: data-volume-template
               reclaimPolicy: Retain

--- a/scenarios/sre/project/roles/tools/tasks/install_istio.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install_istio.yaml
@@ -72,8 +72,8 @@
       spec:
         selector:
           matchLabels:
-            app.kubernetes.io/name: "{{ tools_managers.istio_istiod.helm.release.name }}"
-            app.kubernetes.io/part-of: istio
+            "app.kubernetes.io/name": "{{ tools_managers.istio_istiod.helm.release.name }}"
+            "app.kubernetes.io/part-of": istio
         endpoints:
           - interval: 30s
             port: http-monitoring
@@ -114,8 +114,8 @@
       spec:
         selector:
           matchLabels:
-            app.kubernetes.io/name: "{{ tools_managers.istio_cni.helm.release.name }}"
-            app.kubernetes.io/part-of: istio
+            "app.kubernetes.io/name": "{{ tools_managers.istio_cni.helm.release.name }}"
+            "app.kubernetes.io/part-of": istio
         podMetricsEndpoints:
           - interval: 30s
             port: metrics
@@ -156,8 +156,8 @@
       spec:
         selector:
           matchLabels:
-            app.kubernetes.io/name: "{{ tools_managers.istio_ztunnel.helm.release.name }}"
-            app.kubernetes.io/part-of: istio
+            "app.kubernetes.io/name": "{{ tools_managers.istio_ztunnel.helm.release.name }}"
+            "app.kubernetes.io/part-of": istio
         podMetricsEndpoints:
           - interval: 30s
             port: ztunnel-stats

--- a/scenarios/sre/project/roles/tools/tasks/install_opentelemetry_collectors.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install_opentelemetry_collectors.yaml
@@ -152,8 +152,8 @@
       kind: ClusterRole
       metadata:
         labels:
-          app.kubernetes.io/component: opentelemetry-collector
-          app.kubernetes.io/managed-by: ITBench
+          "app.kubernetes.io/component": opentelemetry-collector
+          "app.kubernetes.io/managed-by": ITBench
         name: "{{ tools_managers.opentelemetry_operator.instances.names.kubernetes_events }}"
       rules:
         - apiGroups:
@@ -180,8 +180,8 @@
       kind: ClusterRoleBinding
       metadata:
         labels:
-          app.kubernetes.io/component: opentelemetry-collector
-          app.kubernetes.io/managed-by: ITBench
+          "app.kubernetes.io/component": opentelemetry-collector
+          "app.kubernetes.io/managed-by": ITBench
         name: "{{ tools_managers.opentelemetry_operator.instances.names.kubernetes_events }}"
       roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -262,8 +262,8 @@
       kind: ClusterRole
       metadata:
         labels:
-          app.kubernetes.io/component: opentelemetry-collector
-          app.kubernetes.io/managed-by: ITBench
+          "app.kubernetes.io/component": opentelemetry-collector
+          "app.kubernetes.io/managed-by": ITBench
         name: "{{ tools_managers.opentelemetry_operator.instances.names.kubernetes_objects_snapshot }}"
       rules:
         - apiGroups:
@@ -359,8 +359,8 @@
       kind: ClusterRoleBinding
       metadata:
         labels:
-          app.kubernetes.io/component: opentelemetry-collector
-          app.kubernetes.io/managed-by: ITBench
+          "app.kubernetes.io/component": opentelemetry-collector
+          "app.kubernetes.io/managed-by": ITBench
         name: "{{ tools_managers.opentelemetry_operator.instances.names.kubernetes_objects_snapshot }}"
       roleRef:
         apiGroup: rbac.authorization.k8s.io

--- a/scenarios/sre/project/roles/waiters/molecule/delete_workload_pods/create.yml
+++ b/scenarios/sre/project/roles/waiters/molecule/delete_workload_pods/create.yml
@@ -26,11 +26,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-deployment-standard
+                "app.kubernetes.io/name": test-deployment-standard
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-deployment-standard
+                  "app.kubernetes.io/name": test-deployment-standard
               spec:
                 containers:
                   - name: server
@@ -56,11 +56,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-deployment-pending
+                "app.kubernetes.io/name": test-deployment-pending
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-deployment-pending
+                  "app.kubernetes.io/name": test-deployment-pending
               spec:
                 containers:
                   - name: server
@@ -86,12 +86,12 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-statefulset-standard
+                "app.kubernetes.io/name": test-statefulset-standard
             serviceName: test-statefulset-standard
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-statefulset-standard
+                  "app.kubernetes.io/name": test-statefulset-standard
               spec:
                 containers:
                   - name: server
@@ -117,12 +117,12 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-statefulset-pending
+                "app.kubernetes.io/name": test-statefulset-pending
             serviceName: test-statefulset-pending
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-statefulset-pending
+                  "app.kubernetes.io/name": test-statefulset-pending
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/waiters/molecule/restart_kubernetes_workload/create.yml
+++ b/scenarios/sre/project/roles/waiters/molecule/restart_kubernetes_workload/create.yml
@@ -26,11 +26,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-workload
+                "app.kubernetes.io/name": test-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-workload
+                  "app.kubernetes.io/name": test-workload
               spec:
                 containers:
                   - name: server

--- a/scenarios/sre/project/roles/waiters/molecule/scale_kubernetes_workload/create.yml
+++ b/scenarios/sre/project/roles/waiters/molecule/scale_kubernetes_workload/create.yml
@@ -26,11 +26,11 @@
             replicas: 2
             selector:
               matchLabels:
-                app.kubernetes.io/name: test-workload
+                "app.kubernetes.io/name": test-workload
             template:
               metadata:
                 labels:
-                  app.kubernetes.io/name: test-workload
+                  "app.kubernetes.io/name": test-workload
               spec:
                 containers:
                   - name: server


### PR DESCRIPTION
This PR updates the otel demo helm values template. The Jaeger exporter should now be `otlp/jaeger` over `otlp`. ~~This also nullifies certain unused blocks.~~