### PR TITLE
docs(sre): add yaml-language-server schema modelines to library entries

### DIFF
--- a/scenarios/sre/project/roles/documentation/files/library/applications/indexes/1.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/applications/indexes/1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/applications/indexes/2.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/applications/indexes/2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/1.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/10.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/10.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/11.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/11.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/12.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/12.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/13.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/13.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/14.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/14.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/15.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/15.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/16.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/16.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/17.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/17.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/18.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/18.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/19.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/19.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/2.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/20.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/20.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/21.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/21.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/22.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/22.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/23.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/23.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/24.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/24.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/25.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/25.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/26.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/26.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/27.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/27.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/28.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/28.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/29.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/29.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/3.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/3.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/30.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/30.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/4.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/4.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   goldenSignal:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/5.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/5.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/6.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/6.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/7.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/7.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/8.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/8.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/faults/indexes/9.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/faults/indexes/9.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   application:

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/1.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/102.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/102.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/105.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/105.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodCrashLooping

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/114.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/114.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestErrorRate

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/16.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/16.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/18.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/18.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/20.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/20.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/23.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/23.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/26.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/26.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/27.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/27.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/3.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/3.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/30.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/30.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestErrorRate

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/31.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/31.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - NoRequestsReceived

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/33.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/33.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/34.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/34.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestLatency

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/36.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/36.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestErrorRate

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/37.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/37.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: finops

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/38.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/38.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubeHpaMaxedOut

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/39.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/39.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/40.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/40.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodCrashLooping

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/41.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/41.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/42.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/42.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/43.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/43.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestErrorRate

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/44.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/44.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/45.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/45.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubeContainerWaiting

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/46.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/46.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodCrashLooping

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/47.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/47.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - NoRequestsReceived

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/48.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/48.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - NoRequestsReceived

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/49.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/49.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/50.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/50.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestErrorRate

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/51.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/51.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - HighRequestLatency

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/52.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/52.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/53.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/53.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/54.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/54.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/55.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/55.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts: []
 category: sre

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/56.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/56.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/57.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/57.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubePodNotReady

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/58.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/58.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - NoRequestsReceived

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/59.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/59.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubeContainerWaiting

--- a/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/60.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/scenarios/indexes/60.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 alerts:
   - KubeContainerWaiting

--- a/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/1.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/1.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/2.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/2.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/3.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/3.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/4.yaml
+++ b/scenarios/sre/project/roles/documentation/files/library/waiters/indexes/4.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schema.json
 ---
 arguments:
   jsonSchema:

--- a/scenarios/sre/project/roles/documentation/tasks/generate_scenarios_docs.yaml
+++ b/scenarios/sre/project/roles/documentation/tasks/generate_scenarios_docs.yaml
@@ -253,6 +253,7 @@
 - name: Generate scenario indexes
   ansible.builtin.copy:
     content: |-
+      # yaml-language-server: $schema=../schema.json
       {{
         scenario |
         ansible.utils.remove_keys(target=["index"]) |

--- a/scenarios/sre/project/roles/generator/tasks/generate_fault_index.yaml
+++ b/scenarios/sre/project/roles/generator/tasks/generate_fault_index.yaml
@@ -34,6 +34,7 @@
 - name: Create new fault index
   ansible.builtin.copy:
     content: |-
+      # yaml-language-server: $schema=../schema.json
       {{
         fault |
         ansible.builtin.to_nice_yaml(explicit_start=true, indent=2)


### PR DESCRIPTION
This PR adds a `yaml-language-server` modeline pointing at the library's `schema.json` to every library index entry, so editors validate and autocomplete the fields while editing (closes #171). A `$schema` key in the YAML body wouldn't do anything in VS Code, hence the comment form. Since scenario indexes are rewritten by `make generate-docs` and `to_nice_yaml` drops comments, the modeline is emitted by the generation task itself, and the same for the fault index scaffolder. Verified with `make validate-docs` and by regenerating the docs on a clean checkout, which left the tree byte-identical apart from the 78 added lines.