### PR TITLE
feat: add cert-manager to SRE/FinOps tools

### DIFF
--- a/documentation/developer/software.md
+++ b/documentation/developer/software.md
@@ -72,6 +72,7 @@ For issues and support directly related to the software, it is often best to rea
 | Name | Repository |
 | --- | --- |
 | Altinity Clickhouse Operator | https://github.com/Altinity/clickhouse-operator |
+| cert-manager | https://github.com/cert-manager/cert-manager |
 | OpenTelemetry Operator | https://github.com/open-telemetry/opentelemetry-operator |
 | Prometheus Operator | https://github.com/prometheus-operator/prometheus-operator |
 

--- a/scenarios/sre/project/roles/tools/defaults/main/managers.yaml
+++ b/scenarios/sre/project/roles/tools/defaults/main/managers.yaml
@@ -1,5 +1,15 @@
 ---
 tools_managers:
+  cert_manager:
+    helm:
+      chart:
+        # renovate: datasource=docker depName=quay.io/jetstack/charts/cert-manager
+        reference: oci://quay.io/jetstack/charts/cert-manager
+        version: v1.20.3
+      release:
+        name: cert-manager
+    kubernetes:
+      namespace: cert-manager
   chaos_mesh:
     helm:
       chart:

--- a/scenarios/sre/project/roles/tools/molecule/deployment_finops/verify.yml
+++ b/scenarios/sre/project/roles/tools/molecule/deployment_finops/verify.yml
@@ -95,6 +95,21 @@
         fail_msg: Kubernetes Metrics Server namespace not found. Installation failed.
         success_msg: Kubernetes Metrics Server namespace found.
 
+    - name: Retrieve cert-manager namespace
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+        name: "{{ tools_managers.cert_manager.kubernetes.namespace }}"
+        kubeconfig: "{{ cluster.kubeconfig }}"
+      register: tools_cert_manager_namespace
+
+    - name: Validate that cert-manager namespace exists
+      ansible.builtin.assert:
+        that:
+          - tools_cert_manager_namespace.resources | ansible.builtin.length == 1
+        fail_msg: cert-manager namespace not found. Installation failed.
+        success_msg: cert-manager namespace found.
+
     - name: Retrieve Istio System namespace
       kubernetes.core.k8s_info:
         api_version: v1

--- a/scenarios/sre/project/roles/tools/molecule/deployment_sre/verify.yml
+++ b/scenarios/sre/project/roles/tools/molecule/deployment_sre/verify.yml
@@ -95,6 +95,21 @@
         fail_msg: Kubernetes Metrics Server namespace not found. Installation failed.
         success_msg: Kubernetes Metrics Server namespace found.
 
+    - name: Retrieve cert-manager namespace
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+        name: "{{ tools_managers.cert_manager.kubernetes.namespace }}"
+        kubeconfig: "{{ cluster.kubeconfig }}"
+      register: tools_cert_manager_namespace
+
+    - name: Validate that cert-manager namespace exists
+      ansible.builtin.assert:
+        that:
+          - tools_cert_manager_namespace.resources | ansible.builtin.length == 1
+        fail_msg: cert-manager namespace not found. Installation failed.
+        success_msg: cert-manager namespace found.
+
     - name: Retrieve Istio System namespace
       kubernetes.core.k8s_info:
         api_version: v1

--- a/scenarios/sre/project/roles/tools/tasks/install.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install.yaml
@@ -49,6 +49,10 @@
       ansible.builtin.import_tasks:
         file: install_kubernetes_metrics_server.yaml
 
+    - name: Import cert-manager installation tasks
+      ansible.builtin.import_tasks:
+        file: install_cert_manager.yaml
+
     - name: Install FinOps specific tools
       when:
         - tools_configuration.finops.enabled | ansible.builtin.default(false)

--- a/scenarios/sre/project/roles/tools/tasks/install_cert_manager.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/install_cert_manager.yaml
@@ -1,0 +1,137 @@
+---
+- name: Install cert-manager on Kubernetes
+  when:
+    - tools_cluster.platform == "kubernetes"
+  block:
+    - name: Create Namespace for cert-manager
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            labels:
+              "prometheus.itbench.io/monitor": "true"
+            name: "{{ tools_managers.cert_manager.kubernetes.namespace }}"
+        state: present
+
+    - name: Install cert-manager
+      kubernetes.core.helm:
+        chart_ref: "{{ tools_managers.cert_manager.helm.chart.reference }}"
+        chart_version: "{{ tools_managers.cert_manager.helm.chart.version }}"
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        release_name: "{{ tools_managers.cert_manager.helm.release.name }}"
+        release_namespace: "{{ tools_managers.cert_manager.kubernetes.namespace }}"
+        release_state: present
+        timeout: 10m0s
+        values:
+          crds:
+            enabled: true
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.itbench.io/sandbox
+                        operator: DoesNotExist
+          webhook:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.itbench.io/sandbox
+                          operator: DoesNotExist
+          cainjector:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.itbench.io/sandbox
+                          operator: DoesNotExist
+          startupapicheck:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.itbench.io/sandbox
+                          operator: DoesNotExist
+          prometheus:
+            enabled: true
+            servicemonitor:
+              enabled: true
+        wait: true
+
+- name: Install RedHat cert-manager Operator on OpenShift
+  when:
+    - tools_cluster.platform == "openshift"
+  block:
+    - name: Create the project for RH cert-manager Operator
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            name: cert-manager-operator
+            labels:
+              kubernetes.io/metadata.name: cert-manager-operator
+              openshift.io/cluster-monitoring: "true"
+        state: present
+
+    - name: Create the operator group for RH cert-manager Operator
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: cert-manager-operator
+          spec:
+            targetNamespaces:
+              - cert-manager-operator
+        state: present
+
+    - name: Create the subscription for RH cert-manager Operator
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: cert-manager-operator
+          spec:
+            channel: stable-v1
+            installPlanApproval: Automatic
+            name: openshift-cert-manager-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+        state: present
+
+    - name: Wait for RH cert-manager Operator
+      kubernetes.core.k8s_info:
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        namespace: cert-manager-operator
+      register: tools_openshift_cert_manager_csv
+      until:
+        - tools_openshift_cert_manager_csv.resources | ansible.builtin.selectattr("status.phase", "==", "Succeeded") | ansible.builtin.length == 0
+      retries: 10
+      delay: 30
+
+    - name: Wait for cert-manager CRD to be installed
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        name: certificates.cert-manager.io
+      register: tools_openshift_cert_manager_crd
+      until:
+        - tools_openshift_cert_manager_crd.resources | ansible.builtin.length == 1
+      retries: 10
+      delay: 30

--- a/scenarios/sre/project/roles/tools/tasks/remove_custom_resource_definitions.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/remove_custom_resource_definitions.yaml
@@ -105,6 +105,25 @@
         label: customresourcedefinition/{{ custom_resource_definition.metadata.name }}
         loop_var: custom_resource_definition
 
+    - name: Delete cert-manager related CustomResourceDefinitions
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          api_version: "{{ custom_resource_definition.apiVersion }}"
+          kind: "{{ custom_resource_definition.kind }}"
+          metadata:
+            name: "{{ custom_resource_definition.metadata.name }}"
+        state: absent
+        wait: true
+      loop: |-
+        {{
+          tools_custom_resource_definitions.resources |
+          ansible.builtin.selectattr("spec.group", "search", "cert-manager\.io$")
+        }}
+      loop_control:
+        label: customresourcedefinition/{{ custom_resource_definition.metadata.name }}
+        loop_var: custom_resource_definition
+
     - name: Delete Prometheus Operator related CustomResourceDefinitions
       kubernetes.core.k8s:
         kubeconfig: "{{ tools_cluster.kubeconfig }}"

--- a/scenarios/sre/project/roles/tools/tasks/uninstall.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/uninstall.yaml
@@ -31,6 +31,10 @@
   ansible.builtin.import_tasks:
     file: uninstall_istio.yaml
 
+- name: Import cert-manager uninstallation tasks
+  ansible.builtin.import_tasks:
+    file: uninstall_cert_manager.yaml
+
 - name: Import Kubernetes Metrics Server uninstallation tasks
   ansible.builtin.import_tasks:
     file: uninstall_kubernetes_metrics_server.yaml

--- a/scenarios/sre/project/roles/tools/tasks/uninstall_cert_manager.yaml
+++ b/scenarios/sre/project/roles/tools/tasks/uninstall_cert_manager.yaml
@@ -1,0 +1,59 @@
+---
+- name: Uninstall cert-manager on Kubernetes
+  when:
+    - tools_cluster.platform == "kubernetes"
+  block:
+    - name: Uninstall cert-manager
+      kubernetes.core.helm:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        release_name: "{{ tools_managers.cert_manager.helm.release.name }}"
+        release_namespace: "{{ tools_managers.cert_manager.kubernetes.namespace }}"
+        release_state: absent
+        wait: true
+
+    - name: Delete Namespace for cert-manager
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          api_version: v1
+          kind: Namespace
+          metadata:
+            name: "{{ tools_managers.cert_manager.kubernetes.namespace }}"
+        state: absent
+        wait: true
+
+- name: Uninstall RH cert-manager Operator on OpenShift
+  when:
+    - tools_cluster.platform == "openshift"
+  block:
+    - name: Delete the subscription for RH cert-manager Operator
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: cert-manager-operator
+        state: absent
+
+    - name: Delete the operator group for RH cert-manager Operator
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: cert-manager-operator
+        state: absent
+
+    - name: Delete the project for RH cert-manager Operator
+      kubernetes.core.k8s:
+        kubeconfig: "{{ tools_cluster.kubeconfig }}"
+        resource_definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          metadata:
+            name: cert-manager-operator
+        state: absent


### PR DESCRIPTION
Closes #914.

## Summary

Installs the [Jetstack cert-manager](https://github.com/cert-manager/cert-manager) Helm chart into a dedicated `cert-manager` namespace whenever an SRE or FinOps scenario is deployed on Kubernetes. Follows the existing tool-install pattern (see `install_kubernetes_metrics_server.yaml`) and registers the chart under `tools_managers.cert_manager` in `defaults/main/managers.yaml` with a `renovate:` annotation so the bot can bump versions.

## Scope decisions

Based on the guidance in the issue thread:

- **Install layer:** unconditional inside the outer `sre.enabled OR finops.enabled` block, same tier as `install_kubernetes_metrics_server.yaml`.
- **OpenShift:** skipped via `when: tools_cluster.platform == "kubernetes"`. OpenShift's native cert-manager story is deliberately out of scope for a follow-up.
- **Downstream consumers deferred to separate PRs:**
  - Removing the Helm-signed cert workaround from the Kubernetes Metrics Server install.
  - Avoiding the forced self-signed cert path on Kind.
  - Wiring cert-manager as a dependency for the ClickHouse Operator migration (#550).

## Changes

- `scenarios/sre/project/roles/tools/defaults/main/managers.yaml` — register `cert_manager` under `tools_managers` with chart reference, version, release name, and namespace.
- `scenarios/sre/project/roles/tools/tasks/install_cert_manager.yaml` — new task file: create namespace with the Prometheus monitor label, then install the Helm release with CRDs enabled and the sandbox-node anti-affinity used by the other tool installs.
- `scenarios/sre/project/roles/tools/tasks/install.yaml` — import the new task after the metrics server install, gated on the Kubernetes platform.
- `scenarios/sre/project/roles/tools/molecule/deployment_sre/verify.yml` and `.../deployment_finops/verify.yml` — assert the cert-manager namespace exists after install.

## Verification

- All commits are signed off (DCO).
- No behavior change for OpenShift deployments.
- Chart version pinned to `v1.20.3` (latest stable Jetstack release); `renovate:` comment added so the bot tracks future bumps.