### PR TITLE
fix: environment variable not properly passed in update_benchmark_status workflow

### DIFF
--- a/.github/workflows/update_benchmark_status.yaml
+++ b/.github/workflows/update_benchmark_status.yaml
@@ -1,7 +1,7 @@
 name: Update Benchmark Status
 on:
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: '*/10 * * * *'
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -37,6 +37,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          TRIGGER: ${{ env.TRIGGER }}
+          ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
         run: |
           if [[ "$TRIGGER" == "schedule" ]]; then
             echo "Scheduled task: List all issues with the 'track-progress' label"
@@ -44,6 +46,9 @@ jobs:
           elif [[ "$TRIGGER" == "issue_comment" ]]; then
             echo "Issue comment trigger: Store only the commented issue"
             gh issue view "$ISSUE_NUMBER" --json number,author,comments | jq '[.]' > issues.json
+          else
+            echo "Unknown trigger type: $TRIGGER"
+            echo "[]" > issues.json
           fi
           echo "Tracked issues"
           jq -c '[.[].number]' issues.json

--- a/.github/workflows/update_benchmark_status.yaml
+++ b/.github/workflows/update_benchmark_status.yaml
@@ -37,8 +37,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TRIGGER: ${{ env.TRIGGER }}
-          ISSUE_NUMBER: ${{ env.ISSUE_NUMBER }}
         run: |
           if [[ "$TRIGGER" == "schedule" ]]; then
             echo "Scheduled task: List all issues with the 'track-progress' label"


### PR DESCRIPTION
- Add TRIGGER and ISSUE_NUMBER to env section of 'List Issues with track-progress Label' step
- Add else clause to gracefully handle unknown trigger types
- Ensures workflow variables are properly accessible across steps

Fixes #983